### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/AimpHTTP.cpp
+++ b/AimpHTTP.cpp
@@ -216,7 +216,7 @@ void AimpHTTP::RawRequestThread(void *args) {
     char buffer[10240];
     ZeroMemory(buffer, sizeof(buffer));
     int dataLen;
-    if ((dataLen = recv(webSocket, buffer, sizeof(buffer), 0) > 0)) {
+    if ((dataLen = recv(webSocket, buffer, sizeof(buffer), 0)) > 0) {
         if (char *body = strstr(buffer, "\r\n\r\n")) {
             body += 4;
             if (callback && m_initialized && Plugin::instance()->core())


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

[V593](https://www.viva64.com/en/w/v593/) Consider reviewing the expression of the 'A = B > C' kind. The expression is calculated as following: 'A = (B > C)'. aimphttp.cpp 219